### PR TITLE
Correct error with require HTTParty: "cannot load such file -- HTTParty (LoadError)"

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -1,5 +1,5 @@
 require 'sinatra'
-require 'HTTParty'
+require 'httparty'
 require 'json'
 
 get '/' do


### PR DESCRIPTION
With current implementation I see the following error in console (Ubuntu 14.04 via VirtualBox):

```
/home/da/.rvm/rubies/ruby-2.2.0/lib/ruby/site_ruby/2.2.0/rubygems/core_ext/kernel_require.rb:54:in `require': cannot load such file -- HTTParty (LoadError)
    from /home/da/.rvm/rubies/ruby-2.2.0/lib/ruby/site_ruby/2.2.0/rubygems/core_ext/kernel_require.rb:54:in `require'
    from app.rb:2:in `<main>'
```

Everything works fine after correcting `require HTTParty` to lowercase - `require httparty`. Not sure but it seems the reason is described here:
http://guides.rubygems.org/name-your-gem/#dont-use-uppercase-letters
